### PR TITLE
Update order.wxml

### DIFF
--- a/litemall-wx/pages/ucenter/order/order.wxml
+++ b/litemall-wx/pages/ucenter/order/order.wxml
@@ -24,7 +24,7 @@
   </view>
 
   <view class="orders">
-    <navigator url="../orderDetail/orderDetail?id={{item.id}}" class="order" open-type="redirect" wx:for="{{orderList}}" wx:key="id">
+    <navigator url="../orderDetail/orderDetail?id={{item.id}}" class="order" open-type="navigate" wx:for="{{orderList}}" wx:key="id">
       <view class="h">
         <view class="l">订单编号：{{item.orderSn}}</view>
         <view class="r">{{item.orderStatusText}}</view>


### PR DESCRIPTION
解决订单详情页返回时，会直接跳转到个人页面的bug，正常逻辑订单详情页返回会跳转到订单列表页而不是个人页面。